### PR TITLE
Fix inconsistent BakeBit path in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@ sudo make install</code></pre>
 <pre class="pre_3c">palera1n Box V 2.0</pre>
 <p>(*) transfer all files</p>
 <p>to the following NanoPi folder:</p>
-<pre class="pre_3"><code>/root/NanoHatOLED/Bakebit/Software/Python/</code></pre>
+<pre class="pre_3"><code>/root/NanoHatOLED/BakeBit/Software/Python/</code></pre>
 <h2 class="h2_i">confirm and replace existing files</h2>
 </section>
 


### PR DESCRIPTION
## Summary
- standardize BakeBit path capitalization in `index.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842b3b46f64832498223d53bab0dad0