### PR TITLE
Add MIT license and improve README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 palera1nbox
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
+# palera1nbox
 
-Here you can download ALL palera1nbox v2.0.0 files
+This repository hosts the files for palera1nbox v2.0.0.
 
+## Installation
+1. Download `palera1nbox.zip` or any desired release from the [Releases](https://github.com/some_repo/releases) page.
+2. Extract the archive to a directory of your choice.
+3. Open `index.html` in your preferred web browser.
 
-go to Releases and download palera1nbox.zip file or any file that you want
+## Usage
+- Follow the on-screen instructions provided in the webpage to build your own palera1nbox.
+- A detailed tutorial is also available at [palera1nbox.s00r1.com](https://palera1nbox.s00r1.com).
 
-
-To build your own palera1nbox
-You can follow my tutorial here :
-
-https://palera1nbox.s00r1.com
+## License
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add missing MIT license information
- update README with install instructions, usage overview, and link to the license

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842c2d7f530832499264dda09fc2552